### PR TITLE
Building pages from data

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,9 @@
+# Taxonomies and Permalinks needed in the site config
+
+# Taxonomies
+[taxonomies]
+  spec_ref = "specs_refs"
+
+# Permalinks
+[permalinks]
+  specs_refs = "/spec/:title"

--- a/content/specs.md
+++ b/content/specs.md
@@ -1,0 +1,7 @@
+---
+title: Specs
+layout: specs
+specs_refs:
+- aafd21bc-3fae-4e22-bb5c-f7c5e179d24f
+- 0fb262e3-5cef-4730-ae68-4f7018c230a5
+---

--- a/data/specs/0fb262e3-5cef-4730-ae68-4f7018c230a5.json
+++ b/data/specs/0fb262e3-5cef-4730-ae68-4f7018c230a5.json
@@ -1,0 +1,1225 @@
+{
+  "openapi": "3.0.2",
+  "info": {
+    "title": "Swagger Petstore - OpenAPI 3.0",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "termsOfService": "http://swagger.io/terms/",
+    "contact": {
+      "email": "apiteam@swagger.io"
+    },
+    "license": {
+      "name": "Apache 2.0",
+      "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+    },
+    "version": "1.0.11"
+  },
+  "externalDocs": {
+    "description": "Find out more about Swagger",
+    "url": "http://swagger.io"
+  },
+  "servers": [
+    {
+      "url": "/api/v3"
+    }
+  ],
+  "tags": [
+    {
+      "name": "pet",
+      "description": "Everything about your Pets",
+      "externalDocs": {
+        "description": "Find out more",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "store",
+      "description": "Access to Petstore orders",
+      "externalDocs": {
+        "description": "Find out more about our store",
+        "url": "http://swagger.io"
+      }
+    },
+    {
+      "name": "user",
+      "description": "Operations about user"
+    }
+  ],
+  "paths": {
+    "/pet": {
+      "put": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Update an existing pet",
+        "description": "Update an existing pet by Id",
+        "operationId": "updatePet",
+        "requestBody": {
+          "description": "Update an existent pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          },
+          "405": {
+            "description": "Validation exception"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Add a new pet to the store",
+        "description": "Add a new pet to the store",
+        "operationId": "addPet",
+        "requestBody": {
+          "description": "Create a new pet in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Pet"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByStatus": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by status",
+        "description": "Multiple status values can be provided with comma separated strings",
+        "operationId": "findPetsByStatus",
+        "parameters": [
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status values that need to be considered for filter",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "string",
+              "default": "available",
+              "enum": [
+                "available",
+                "pending",
+                "sold"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid status value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/findByTags": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Finds Pets by tags",
+        "description": "Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.",
+        "operationId": "findPetsByTags",
+        "parameters": [
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Tags to filter by",
+            "required": false,
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Pet"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid tag value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}": {
+      "get": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Find pet by ID",
+        "description": "Returns a single pet",
+        "operationId": "getPetById",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to return",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Pet"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Pet not found"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          },
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Updates a pet in the store with form data",
+        "description": "",
+        "operationId": "updatePetWithForm",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet that needs to be updated",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Name of pet that needs to be updated",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Status of pet that needs to be updated",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "405": {
+            "description": "Invalid input"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      },
+      "delete": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "Deletes a pet",
+        "description": "",
+        "operationId": "deletePet",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "header",
+            "description": "",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "Pet id to delete",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid pet value"
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/pet/{petId}/uploadImage": {
+      "post": {
+        "tags": [
+          "pet"
+        ],
+        "summary": "uploads an image",
+        "description": "",
+        "operationId": "uploadFile",
+        "parameters": [
+          {
+            "name": "petId",
+            "in": "path",
+            "description": "ID of pet to update",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "additionalMetadata",
+            "in": "query",
+            "description": "Additional Metadata",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/octet-stream": {
+              "schema": {
+                "type": "string",
+                "format": "binary"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "petstore_auth": [
+              "write:pets",
+              "read:pets"
+            ]
+          }
+        ]
+      }
+    },
+    "/store/inventory": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Returns pet inventories by status",
+        "description": "Returns a map of status codes to quantities",
+        "operationId": "getInventory",
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "integer",
+                    "format": "int32"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/store/order": {
+      "post": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Place an order for a pet",
+        "description": "Place a new order in the store",
+        "operationId": "placeOrder",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Order"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "405": {
+            "description": "Invalid input"
+          }
+        }
+      }
+    },
+    "/store/order/{orderId}": {
+      "get": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Find purchase order by ID",
+        "description": "For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.",
+        "operationId": "getOrderById",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of order that needs to be fetched",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "store"
+        ],
+        "summary": "Delete purchase order by ID",
+        "description": "For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors",
+        "operationId": "deleteOrder",
+        "parameters": [
+          {
+            "name": "orderId",
+            "in": "path",
+            "description": "ID of the order that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid ID supplied"
+          },
+          "404": {
+            "description": "Order not found"
+          }
+        }
+      }
+    },
+    "/user": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Create user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "createUser",
+        "requestBody": {
+          "description": "Created user object",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "successful operation",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/createWithList": {
+      "post": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Creates list of users with given input array",
+        "description": "Creates list of users with given input array",
+        "operationId": "createUsersWithListInput",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/login": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs user into the system",
+        "description": "",
+        "operationId": "loginUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "description": "The user name for login",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "password",
+            "in": "query",
+            "description": "The password for login in clear text",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "headers": {
+              "X-Rate-Limit": {
+                "description": "calls per hour allowed by the user",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              },
+              "X-Expires-After": {
+                "description": "date in UTC when token expires",
+                "schema": {
+                  "type": "string",
+                  "format": "date-time"
+                }
+              }
+            },
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username/password supplied"
+          }
+        }
+      }
+    },
+    "/user/logout": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Logs out current logged in user session",
+        "description": "",
+        "operationId": "logoutUser",
+        "parameters": [],
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      }
+    },
+    "/user/{username}": {
+      "get": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Get user by user name",
+        "description": "",
+        "operationId": "getUserByName",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be fetched. Use user1 for testing. ",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "successful operation",
+            "content": {
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      },
+      "put": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Update user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "name that need to be deleted",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "Update an existent user in the store",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            },
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        },
+        "responses": {
+          "default": {
+            "description": "successful operation"
+          }
+        }
+      },
+      "delete": {
+        "tags": [
+          "user"
+        ],
+        "summary": "Delete user",
+        "description": "This can only be done by the logged in user.",
+        "operationId": "deleteUser",
+        "parameters": [
+          {
+            "name": "username",
+            "in": "path",
+            "description": "The name that needs to be deleted",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Invalid username supplied"
+          },
+          "404": {
+            "description": "User not found"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Order": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "petId": {
+            "type": "integer",
+            "format": "int64",
+            "example": 198772
+          },
+          "quantity": {
+            "type": "integer",
+            "format": "int32",
+            "example": 7
+          },
+          "shipDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "description": "Order Status",
+            "example": "approved",
+            "enum": [
+              "placed",
+              "approved",
+              "delivered"
+            ]
+          },
+          "complete": {
+            "type": "boolean"
+          }
+        },
+        "xml": {
+          "name": "order"
+        }
+      },
+      "Customer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 100000
+          },
+          "username": {
+            "type": "string",
+            "example": "fehguy"
+          },
+          "address": {
+            "type": "array",
+            "xml": {
+              "name": "addresses",
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Address"
+            }
+          }
+        },
+        "xml": {
+          "name": "customer"
+        }
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string",
+            "example": "437 Lytton"
+          },
+          "city": {
+            "type": "string",
+            "example": "Palo Alto"
+          },
+          "state": {
+            "type": "string",
+            "example": "CA"
+          },
+          "zip": {
+            "type": "string",
+            "example": "94301"
+          }
+        },
+        "xml": {
+          "name": "address"
+        }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "example": "Dogs"
+          }
+        },
+        "xml": {
+          "name": "category"
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "username": {
+            "type": "string",
+            "example": "theUser"
+          },
+          "firstName": {
+            "type": "string",
+            "example": "John"
+          },
+          "lastName": {
+            "type": "string",
+            "example": "James"
+          },
+          "email": {
+            "type": "string",
+            "example": "john@email.com"
+          },
+          "password": {
+            "type": "string",
+            "example": "12345"
+          },
+          "phone": {
+            "type": "string",
+            "example": "12345"
+          },
+          "userStatus": {
+            "type": "integer",
+            "description": "User Status",
+            "format": "int32",
+            "example": 1
+          }
+        },
+        "xml": {
+          "name": "user"
+        }
+      },
+      "Tag": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "tag"
+        }
+      },
+      "Pet": {
+        "required": [
+          "name",
+          "photoUrls"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64",
+            "example": 10
+          },
+          "name": {
+            "type": "string",
+            "example": "doggie"
+          },
+          "category": {
+            "$ref": "#/components/schemas/Category"
+          },
+          "photoUrls": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "type": "string",
+              "xml": {
+                "name": "photoUrl"
+              }
+            }
+          },
+          "tags": {
+            "type": "array",
+            "xml": {
+              "wrapped": true
+            },
+            "items": {
+              "$ref": "#/components/schemas/Tag"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "pet status in the store",
+            "enum": [
+              "available",
+              "pending",
+              "sold"
+            ]
+          }
+        },
+        "xml": {
+          "name": "pet"
+        }
+      },
+      "ApiResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "xml": {
+          "name": "##default"
+        }
+      }
+    },
+    "requestBodies": {
+      "Pet": {
+        "description": "Pet object that needs to be added to the store",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          },
+          "application/xml": {
+            "schema": {
+              "$ref": "#/components/schemas/Pet"
+            }
+          }
+        }
+      },
+      "UserArray": {
+        "description": "List of user object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/User"
+              }
+            }
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "petstore_auth": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://petstore3.swagger.io/oauth/authorize",
+            "scopes": {
+              "write:pets": "modify pets in your account",
+              "read:pets": "read your pets"
+            }
+          }
+        }
+      },
+      "api_key": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "header"
+      }
+    }
+  }
+}

--- a/data/specs/aafd21bc-3fae-4e22-bb5c-f7c5e179d24f.json
+++ b/data/specs/aafd21bc-3fae-4e22-bb5c-f7c5e179d24f.json
@@ -1,0 +1,1794 @@
+{
+  "basePath": "/",
+  "definitions": {},
+  "host": "httpbin.org",
+  "info": {
+    "contact": {
+      "email": "me@kennethreitz.org",
+      "responsibleDeveloper": "Kenneth Reitz",
+      "responsibleOrganization": "Kenneth Reitz",
+      "url": "https://kennethreitz.org"
+    },
+    "description": "A simple HTTP Request & Response Service.<br/> <br/> <b>Run locally: </b> <code>$ docker run -p 80:80 kennethreitz/httpbin</code>",
+    "title": "httpbin.org",
+    "version": "0.9.2"
+  },
+  "paths": {
+    "/absolute-redirect/{n}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "n",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "Absolutely 302 Redirects n times.",
+        "tags": [
+          "Redirects"
+        ]
+      }
+    },
+    "/anything": {
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "patch": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "put": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "trace": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      }
+    },
+    "/anything/{anything}": {
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "patch": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "put": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      },
+      "trace": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Anything passed in request"
+          }
+        },
+        "summary": "Returns anything passed in request data.",
+        "tags": [
+          "Anything"
+        ]
+      }
+    },
+    "/base64/{value}": {
+      "get": {
+        "parameters": [
+          {
+            "default": "SFRUUEJJTiBpcyBhd2Vzb21l",
+            "in": "path",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "Decoded base64 content."
+          }
+        },
+        "summary": "Decodes base64url-encoded string.",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/basic-auth/{user}/{passwd}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "passwd",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucessful authentication."
+          },
+          "401": {
+            "description": "Unsuccessful authentication."
+          }
+        },
+        "summary": "Prompts the user for authorization using HTTP Basic Auth.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/bearer": {
+      "get": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "Authorization",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucessful authentication."
+          },
+          "401": {
+            "description": "Unsuccessful authentication."
+          }
+        },
+        "summary": "Prompts the user for authorization using bearer authentication.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/brotli": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Brotli-encoded data."
+          }
+        },
+        "summary": "Returns Brotli-encoded data.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    },
+    "/bytes/{n}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "n",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "Bytes."
+          }
+        },
+        "summary": "Returns n random bytes generated with given seed",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/cache": {
+      "get": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-Modified-Since"
+          },
+          {
+            "in": "header",
+            "name": "If-None-Match"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Cached response"
+          },
+          "304": {
+            "description": "Modified"
+          }
+        },
+        "summary": "Returns a 304 if an If-Modified-Since header or If-None-Match is present. Returns the same as a GET otherwise.",
+        "tags": [
+          "Response inspection"
+        ]
+      }
+    },
+    "/cache/{value}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "value",
+            "type": "integer"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Cache control set"
+          }
+        },
+        "summary": "Sets a Cache-Control header for n seconds.",
+        "tags": [
+          "Response inspection"
+        ]
+      }
+    },
+    "/cookies": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Set cookies."
+          }
+        },
+        "summary": "Returns cookie data.",
+        "tags": [
+          "Cookies"
+        ]
+      }
+    },
+    "/cookies/delete": {
+      "get": {
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "explode": true,
+            "in": "query",
+            "name": "freeform",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "style": "form"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Redirect to cookie list"
+          }
+        },
+        "summary": "Deletes cookie(s) as provided by the query string and redirects to cookie list.",
+        "tags": [
+          "Cookies"
+        ]
+      }
+    },
+    "/cookies/set": {
+      "get": {
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "explode": true,
+            "in": "query",
+            "name": "freeform",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "style": "form"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Redirect to cookie list"
+          }
+        },
+        "summary": "Sets cookie(s) as provided by the query string and redirects to cookie list.",
+        "tags": [
+          "Cookies"
+        ]
+      }
+    },
+    "/cookies/set/{name}/{value}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "name",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "value",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Set cookies and redirects to cookie list."
+          }
+        },
+        "summary": "Sets a cookie and redirects to cookie list.",
+        "tags": [
+          "Cookies"
+        ]
+      }
+    },
+    "/deflate": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Defalte-encoded data."
+          }
+        },
+        "summary": "Returns Deflate-encoded data.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    },
+    "/delay/{delay}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "delay",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A delayed response."
+          }
+        },
+        "summary": "Returns a delayed response (max of 10 seconds).",
+        "tags": [
+          "Dynamic data"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "delay",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A delayed response."
+          }
+        },
+        "summary": "Returns a delayed response (max of 10 seconds).",
+        "tags": [
+          "Dynamic data"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "delay",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A delayed response."
+          }
+        },
+        "summary": "Returns a delayed response (max of 10 seconds).",
+        "tags": [
+          "Dynamic data"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "delay",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A delayed response."
+          }
+        },
+        "summary": "Returns a delayed response (max of 10 seconds).",
+        "tags": [
+          "Dynamic data"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "delay",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A delayed response."
+          }
+        },
+        "summary": "Returns a delayed response (max of 10 seconds).",
+        "tags": [
+          "Dynamic data"
+        ]
+      },
+      "trace": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "delay",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A delayed response."
+          }
+        },
+        "summary": "Returns a delayed response (max of 10 seconds).",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/delete": {
+      "delete": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request's DELETE parameters."
+          }
+        },
+        "summary": "The request's DELETE parameters.",
+        "tags": [
+          "HTTP Methods"
+        ]
+      }
+    },
+    "/deny": {
+      "get": {
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Denied message"
+          }
+        },
+        "summary": "Returns page denied by robots.txt rules.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    },
+    "/digest-auth/{qop}/{user}/{passwd}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "auth or auth-int",
+            "in": "path",
+            "name": "qop",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "user",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "passwd",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucessful authentication."
+          },
+          "401": {
+            "description": "Unsuccessful authentication."
+          }
+        },
+        "summary": "Prompts the user for authorization using Digest Auth.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/digest-auth/{qop}/{user}/{passwd}/{algorithm}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "auth or auth-int",
+            "in": "path",
+            "name": "qop",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "user",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "passwd",
+            "type": "string"
+          },
+          {
+            "default": "MD5",
+            "description": "MD5, SHA-256, SHA-512",
+            "in": "path",
+            "name": "algorithm",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucessful authentication."
+          },
+          "401": {
+            "description": "Unsuccessful authentication."
+          }
+        },
+        "summary": "Prompts the user for authorization using Digest Auth + Algorithm.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/digest-auth/{qop}/{user}/{passwd}/{algorithm}/{stale_after}": {
+      "get": {
+        "description": "allow settings the stale_after argument.\n",
+        "parameters": [
+          {
+            "description": "auth or auth-int",
+            "in": "path",
+            "name": "qop",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "user",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "passwd",
+            "type": "string"
+          },
+          {
+            "default": "MD5",
+            "description": "MD5, SHA-256, SHA-512",
+            "in": "path",
+            "name": "algorithm",
+            "type": "string"
+          },
+          {
+            "default": "never",
+            "in": "path",
+            "name": "stale_after",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucessful authentication."
+          },
+          "401": {
+            "description": "Unsuccessful authentication."
+          }
+        },
+        "summary": "Prompts the user for authorization using Digest Auth + Algorithm.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/drip": {
+      "get": {
+        "parameters": [
+          {
+            "default": 2,
+            "description": "The amount of time (in seconds) over which to drip each byte",
+            "in": "query",
+            "name": "duration",
+            "required": false,
+            "type": "number"
+          },
+          {
+            "default": 10,
+            "description": "The number of bytes to respond with",
+            "in": "query",
+            "name": "numbytes",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "default": 200,
+            "description": "The response code that will be returned",
+            "in": "query",
+            "name": "code",
+            "required": false,
+            "type": "integer"
+          },
+          {
+            "default": 2,
+            "description": "The amount of time (in seconds) to delay before responding",
+            "in": "query",
+            "name": "delay",
+            "required": false,
+            "type": "number"
+          }
+        ],
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "A dripped response."
+          }
+        },
+        "summary": "Drips data over a duration after an optional initial delay.",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/encoding/utf8": {
+      "get": {
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "Encoded UTF-8 content."
+          }
+        },
+        "summary": "Returns a UTF-8 encoded body.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    },
+    "/etag/{etag}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "header",
+            "name": "If-None-Match"
+          },
+          {
+            "in": "header",
+            "name": "If-Match"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Normal response"
+          },
+          "412": {
+            "description": "match"
+          }
+        },
+        "summary": "Assumes the resource has the given etag and responds to If-None-Match and If-Match headers appropriately.",
+        "tags": [
+          "Response inspection"
+        ]
+      }
+    },
+    "/get": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request's query parameters."
+          }
+        },
+        "summary": "The request's query parameters.",
+        "tags": [
+          "HTTP Methods"
+        ]
+      }
+    },
+    "/gzip": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "GZip-encoded data."
+          }
+        },
+        "summary": "Returns GZip-encoded data.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    },
+    "/headers": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request's headers."
+          }
+        },
+        "summary": "Return the incoming request's HTTP headers.",
+        "tags": [
+          "Request inspection"
+        ]
+      }
+    },
+    "/hidden-basic-auth/{user}/{passwd}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user",
+            "type": "string"
+          },
+          {
+            "in": "path",
+            "name": "passwd",
+            "type": "string"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Sucessful authentication."
+          },
+          "404": {
+            "description": "Unsuccessful authentication."
+          }
+        },
+        "summary": "Prompts the user for authorization using HTTP Basic Auth.",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/html": {
+      "get": {
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "An HTML page."
+          }
+        },
+        "summary": "Returns a simple HTML document.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    },
+    "/image": {
+      "get": {
+        "produces": [
+          "image/webp",
+          "image/svg+xml",
+          "image/jpeg",
+          "image/png",
+          "image/*"
+        ],
+        "responses": {
+          "200": {
+            "description": "An image."
+          }
+        },
+        "summary": "Returns a simple image of the type suggest by the Accept header.",
+        "tags": [
+          "Images"
+        ]
+      }
+    },
+    "/image/jpeg": {
+      "get": {
+        "produces": [
+          "image/jpeg"
+        ],
+        "responses": {
+          "200": {
+            "description": "A JPEG image."
+          }
+        },
+        "summary": "Returns a simple JPEG image.",
+        "tags": [
+          "Images"
+        ]
+      }
+    },
+    "/image/png": {
+      "get": {
+        "produces": [
+          "image/png"
+        ],
+        "responses": {
+          "200": {
+            "description": "A PNG image."
+          }
+        },
+        "summary": "Returns a simple PNG image.",
+        "tags": [
+          "Images"
+        ]
+      }
+    },
+    "/image/svg": {
+      "get": {
+        "produces": [
+          "image/svg+xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "An SVG image."
+          }
+        },
+        "summary": "Returns a simple SVG image.",
+        "tags": [
+          "Images"
+        ]
+      }
+    },
+    "/image/webp": {
+      "get": {
+        "produces": [
+          "image/webp"
+        ],
+        "responses": {
+          "200": {
+            "description": "A WEBP image."
+          }
+        },
+        "summary": "Returns a simple WEBP image.",
+        "tags": [
+          "Images"
+        ]
+      }
+    },
+    "/ip": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The Requester's IP Address."
+          }
+        },
+        "summary": "Returns the requester's IP Address.",
+        "tags": [
+          "Request inspection"
+        ]
+      }
+    },
+    "/json": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "An JSON document."
+          }
+        },
+        "summary": "Returns a simple JSON document.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    },
+    "/links/{n}/{offset}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "n",
+            "type": "int"
+          },
+          {
+            "in": "path",
+            "name": "offset",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "200": {
+            "description": "HTML links."
+          }
+        },
+        "summary": "Generate a page containing n links to other pages which do the same.",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/patch": {
+      "patch": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request's PATCH parameters."
+          }
+        },
+        "summary": "The request's PATCH parameters.",
+        "tags": [
+          "HTTP Methods"
+        ]
+      }
+    },
+    "/post": {
+      "post": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request's POST parameters."
+          }
+        },
+        "summary": "The request's POST parameters.",
+        "tags": [
+          "HTTP Methods"
+        ]
+      }
+    },
+    "/put": {
+      "put": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request's PUT parameters."
+          }
+        },
+        "summary": "The request's PUT parameters.",
+        "tags": [
+          "HTTP Methods"
+        ]
+      }
+    },
+    "/range/{numbytes}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "numbytes",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "Bytes."
+          }
+        },
+        "summary": "Streams n random bytes generated with given seed, at given chunk size per packet.",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/redirect-to": {
+      "delete": {
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "302/3XX Redirects to the given URL.",
+        "tags": [
+          "Redirects"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "query",
+            "name": "url",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "query",
+            "name": "status_code",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "302/3XX Redirects to the given URL.",
+        "tags": [
+          "Redirects"
+        ]
+      },
+      "patch": {
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "302/3XX Redirects to the given URL.",
+        "tags": [
+          "Redirects"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "in": "formData",
+            "name": "url",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "formData",
+            "name": "status_code",
+            "required": false,
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "302/3XX Redirects to the given URL.",
+        "tags": [
+          "Redirects"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "formData",
+            "name": "url",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "in": "formData",
+            "name": "status_code",
+            "required": false,
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "302/3XX Redirects to the given URL.",
+        "tags": [
+          "Redirects"
+        ]
+      },
+      "trace": {
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "302/3XX Redirects to the given URL.",
+        "tags": [
+          "Redirects"
+        ]
+      }
+    },
+    "/redirect/{n}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "n",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "302 Redirects n times.",
+        "tags": [
+          "Redirects"
+        ]
+      }
+    },
+    "/relative-redirect/{n}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "n",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "text/html"
+        ],
+        "responses": {
+          "302": {
+            "description": "A redirection."
+          }
+        },
+        "summary": "Relatively 302 Redirects n times.",
+        "tags": [
+          "Redirects"
+        ]
+      }
+    },
+    "/response-headers": {
+      "get": {
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "explode": true,
+            "in": "query",
+            "name": "freeform",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "style": "form"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Response headers"
+          }
+        },
+        "summary": "Returns a set of response headers from the query string.",
+        "tags": [
+          "Response inspection"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "allowEmptyValue": true,
+            "explode": true,
+            "in": "query",
+            "name": "freeform",
+            "schema": {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            "style": "form"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Response headers"
+          }
+        },
+        "summary": "Returns a set of response headers from the query string.",
+        "tags": [
+          "Response inspection"
+        ]
+      }
+    },
+    "/robots.txt": {
+      "get": {
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "200": {
+            "description": "Robots file"
+          }
+        },
+        "summary": "Returns some robots.txt rules.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    },
+    "/status/{codes}": {
+      "delete": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "codes"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "100": {
+            "description": "Informational responses"
+          },
+          "200": {
+            "description": "Success"
+          },
+          "300": {
+            "description": "Redirection"
+          },
+          "400": {
+            "description": "Client Errors"
+          },
+          "500": {
+            "description": "Server Errors"
+          }
+        },
+        "summary": "Return status code or random status code if more than one are given",
+        "tags": [
+          "Status codes"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "codes"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "100": {
+            "description": "Informational responses"
+          },
+          "200": {
+            "description": "Success"
+          },
+          "300": {
+            "description": "Redirection"
+          },
+          "400": {
+            "description": "Client Errors"
+          },
+          "500": {
+            "description": "Server Errors"
+          }
+        },
+        "summary": "Return status code or random status code if more than one are given",
+        "tags": [
+          "Status codes"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "codes"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "100": {
+            "description": "Informational responses"
+          },
+          "200": {
+            "description": "Success"
+          },
+          "300": {
+            "description": "Redirection"
+          },
+          "400": {
+            "description": "Client Errors"
+          },
+          "500": {
+            "description": "Server Errors"
+          }
+        },
+        "summary": "Return status code or random status code if more than one are given",
+        "tags": [
+          "Status codes"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "codes"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "100": {
+            "description": "Informational responses"
+          },
+          "200": {
+            "description": "Success"
+          },
+          "300": {
+            "description": "Redirection"
+          },
+          "400": {
+            "description": "Client Errors"
+          },
+          "500": {
+            "description": "Server Errors"
+          }
+        },
+        "summary": "Return status code or random status code if more than one are given",
+        "tags": [
+          "Status codes"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "codes"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "100": {
+            "description": "Informational responses"
+          },
+          "200": {
+            "description": "Success"
+          },
+          "300": {
+            "description": "Redirection"
+          },
+          "400": {
+            "description": "Client Errors"
+          },
+          "500": {
+            "description": "Server Errors"
+          }
+        },
+        "summary": "Return status code or random status code if more than one are given",
+        "tags": [
+          "Status codes"
+        ]
+      },
+      "trace": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "codes"
+          }
+        ],
+        "produces": [
+          "text/plain"
+        ],
+        "responses": {
+          "100": {
+            "description": "Informational responses"
+          },
+          "200": {
+            "description": "Success"
+          },
+          "300": {
+            "description": "Redirection"
+          },
+          "400": {
+            "description": "Client Errors"
+          },
+          "500": {
+            "description": "Server Errors"
+          }
+        },
+        "summary": "Return status code or random status code if more than one are given",
+        "tags": [
+          "Status codes"
+        ]
+      }
+    },
+    "/stream-bytes/{n}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "n",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/octet-stream"
+        ],
+        "responses": {
+          "200": {
+            "description": "Bytes."
+          }
+        },
+        "summary": "Streams n random bytes generated with given seed, at given chunk size per packet.",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/stream/{n}": {
+      "get": {
+        "parameters": [
+          {
+            "in": "path",
+            "name": "n",
+            "type": "int"
+          }
+        ],
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "Streamed JSON responses."
+          }
+        },
+        "summary": "Stream n JSON responses",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/user-agent": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "The request's User-Agent header."
+          }
+        },
+        "summary": "Return the incoming requests's User-Agent header.",
+        "tags": [
+          "Request inspection"
+        ]
+      }
+    },
+    "/uuid": {
+      "get": {
+        "produces": [
+          "application/json"
+        ],
+        "responses": {
+          "200": {
+            "description": "A UUID4."
+          }
+        },
+        "summary": "Return a UUID4.",
+        "tags": [
+          "Dynamic data"
+        ]
+      }
+    },
+    "/xml": {
+      "get": {
+        "produces": [
+          "application/xml"
+        ],
+        "responses": {
+          "200": {
+            "description": "An XML document."
+          }
+        },
+        "summary": "Returns a simple XML document.",
+        "tags": [
+          "Response formats"
+        ]
+      }
+    }
+  },
+  "protocol": "https",
+  "schemes": [
+    "https"
+  ],
+  "swagger": "2.0",
+  "tags": [
+    {
+      "description": "Testing different HTTP verbs",
+      "name": "HTTP Methods"
+    },
+    {
+      "description": "Auth methods",
+      "name": "Auth"
+    },
+    {
+      "description": "Generates responses with given status code",
+      "name": "Status codes"
+    },
+    {
+      "description": "Inspect the request data",
+      "name": "Request inspection"
+    },
+    {
+      "description": "Inspect the response data like caching and headers",
+      "name": "Response inspection"
+    },
+    {
+      "description": "Returns responses in different data formats",
+      "name": "Response formats"
+    },
+    {
+      "description": "Generates random and dynamic data",
+      "name": "Dynamic data"
+    },
+    {
+      "description": "Creates, reads and deletes Cookies",
+      "name": "Cookies"
+    },
+    {
+      "description": "Returns different image formats",
+      "name": "Images"
+    },
+    {
+      "description": "Returns different redirect responses",
+      "name": "Redirects"
+    },
+    {
+      "description": "Returns anything that is passed to request",
+      "name": "Anything"
+    }
+  ]
+}

--- a/data/specs/index.json
+++ b/data/specs/index.json
@@ -1,0 +1,26 @@
+{
+  "aafd21bc-3fae-4e22-bb5c-f7c5e179d24f": {
+    "id": "aafd21bc-3fae-4e22-bb5c-f7c5e179d24f",
+    "name": "httpbin.org",
+    "description": "A simple HTTP Request & Response Service.<br/> <br/> <b>Run locally: </b> <code>$ docker run -p 80:80 kennethreitz/httpbin</code>",
+    "createdOn": "2022-03-15T16:16:04+0000",
+    "createdBy": "",
+    "type": "OPENAPI",
+    "state": "ENABLED",
+    "modifiedOn": "2022-03-15T16:16:04+0000",
+    "modifiedBy": "",
+    "groupId": "production"
+  },
+  "0fb262e3-5cef-4730-ae68-4f7018c230a5": {
+    "id": "0fb262e3-5cef-4730-ae68-4f7018c230a5",
+    "name": "Swagger Petstore - OpenAPI 3.0",
+    "description": "This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about\nSwagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!\nYou can now help us improve the API whether it's by making changes to the definition itself or to the code.\nThat way, with time, we can improve the API in general, and expose some of the new features in OAS3.\n\nSome useful links:\n- [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)\n- [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)",
+    "createdOn": "2022-03-15T16:16:49+0000",
+    "createdBy": "",
+    "type": "OPENAPI",
+    "state": "ENABLED",
+    "modifiedOn": "2022-03-15T16:16:49+0000",
+    "modifiedBy": "",
+    "groupId": "production"
+  }
+}

--- a/layouts/_default/specs.html
+++ b/layouts/_default/specs.html
@@ -1,0 +1,7 @@
+{{ define "main" }}
+<ul>
+    {{ range partialCached "func/GetSpecPages" "GetSpecPages" }}
+        {{ partialCached "spec" . . }}
+    {{ end }}
+</ul>
+{{ end }}

--- a/layouts/partials/func/GetSpecData.html
+++ b/layouts/partials/func/GetSpecData.html
@@ -1,0 +1,30 @@
+{{/*
+GetSpecData
+Retrieves the data of a spec given a key
+
+@author @didierofrivia
+
+@context String
+
+@access private
+
+@returns Map
+String (.name)
+String (.id)
+String (.description)
+String (.type)
+String (.state)
+String (.createdOn)
+
+@example - Go Template
+Variant is the lone parameter
+{{ with partialCached "GetSpecData" "the-spec-id" "the-spec-id" }}
+This is the spec description {{ .description }}
+{{ end }}
+*/}}
+{{ $spec := dict }}
+{{ with index site.Data.specs.index . }}
+    {{ $spec = . }}
+{{ end }}
+
+{{ return $spec }}

--- a/layouts/partials/func/GetSpecPages.html
+++ b/layouts/partials/func/GetSpecPages.html
@@ -1,0 +1,26 @@
+{{/*
+GetSpecPages
+Retrieves the list of term pages for the `specs_refs` taxonomy.
+
+@author @didierofrivia
+
+@context Any (.)
+
+@access private
+
+@returns Collection of Pages
+
+@example - Go Template
+We don't need a context
+We don't need a variant either as returned value is the same across build
+
+{{ with partialCached "GetSpecPages" "GetSpecPages" }}
+The spec name is {{ .name }}
+{{ end }}
+*/}}
+{{ $specs := slice }}
+{{ range site.Taxonomies.specs_refs }}
+{{ $specs = $specs | append .Page }}
+{{ end }}
+
+{{ return $specs }}

--- a/layouts/partials/spec.html
+++ b/layouts/partials/spec.html
@@ -1,0 +1,4 @@
+{{ $page := . }}
+{{ with partialCached "func/GetSpecData" .Data.Term .Data.Term }}
+<li><a href="{{ $page.RelPermalink }}">{{ .name }}</a></li>
+{{ end }}

--- a/layouts/specs_refs/term.html
+++ b/layouts/specs_refs/term.html
@@ -1,0 +1,19 @@
+{{/*
+    TODO: Extract scripts from this file to a common scripts partial
+*/}}
+
+{{ define "main" }}
+{{ $styleOpts := (dict "includePaths" (slice "node_modules")) }}
+{{ $apiDocsCss := resources.Get "scss/api-docs/main.scss" | resources.ToCSS $styleOpts | resources.Minify }}
+<link type="text/css" rel="stylesheet" href="{{ $apiDocsCss.Permalink }}">
+
+{{ with partialCached "func/GetSpecData" .Data.Term .Data.Term }}
+    {{ $spec := index site.Data.specs .id | jsonify }}
+    <div class="api-docs" id="api-docs" data-spec="{{$spec}}"></div>
+{{ end }}
+
+{{ $env := cond .Site.IsServer "\"development\"" "\"production\"" }}
+{{ $opts := dict "defines" (dict "process.env.NODE_ENV" $env) }}
+{{ $apiDocs := resources.Get "js/apiDocs.ts" | babel | js.Build $opts }}
+<script src="{{ $apiDocs.RelPermalink }}"></script>
+{{ end }}


### PR DESCRIPTION
Since Hugo still doesn't provide a way to create pages out of data content (previous workaround introduced by https://github.com/3scale-labs/kamrad/pull/22), this PR is a new take to make it possible.

## Things required to make this work:

* Copy the taxonomies and permalinks from the example config to the site config
```toml
# Taxonomies
[taxonomies]
spec_ref = "specs_refs"

# Permalinks
[permalinks]
specs_refs = "/spec/:title"

```
* Include within the content the `specs.md` as the one provided with the desired spec id list 
```markdown
---
title: Specs
layout: specs
specs_refs:
- aafd21bc-3fae-4e22-bb5c-f7c5e179d24f
- 0fb262e3-5cef-4730-ae68-4f7018c230a5
---
```
* Include within the `data/specs` directory an index.json file providing the specs list metadata with it's required format
`data/specs/index.json`
```json
{
  "aafd21bc-3fae-4e22-bb5c-f7c5e179d24f": {
    "id": "aafd21bc-3fae-4e22-bb5c-f7c5e179d24f",
    "name": "httpbin.org",
    "description": "...",
      },
  "0fb262e3-5cef-4730-ae68-4f7018c230a5": {
    "id": "0fb262e3-5cef-4730-ae68-4f7018c230a5",
    "name": "Swagger Petstore - OpenAPI 3.0",
    "description": "..."
  }
}

```
* Include the individual spec file named with the spec id from the metadata list.
`data/specs/0fb262e3-5cef-4730-ae68-4f7018c230a5.json`
```json
{
  "openapi": "3.0.2",
  "info": {
    "title": "Swagger Petstore - OpenAPI 3.0",
...
```


Note: with the provided examples only needed to copy the config lines.